### PR TITLE
fix(oauth2): retain refresh_token_expires_in in token grant response

### DIFF
--- a/packages/oauth2/src/domains/token/module.ts
+++ b/packages/oauth2/src/domains/token/module.ts
@@ -112,6 +112,10 @@ export class TokenAPI extends BaseAPI {
             tokenResponse.refresh_token = data.refresh_token;
         }
 
+        if (typeof data.refresh_token_expires_in === 'number') {
+            tokenResponse.refresh_token_expires_in = data.refresh_token_expires_in;
+        }
+
         if (typeof data.id_token === 'string') {
             tokenResponse.id_token = data.id_token;
         }

--- a/packages/oauth2/src/domains/token/type.ts
+++ b/packages/oauth2/src/domains/token/type.ts
@@ -62,6 +62,8 @@ export type TokenGrantResponse = {
 
     expires_in: number,
 
+    refresh_token_expires_in?: number,
+
     token_type: string,
 
     id_token?: string,

--- a/packages/oauth2/test/unit/domains/token/create.spec.ts
+++ b/packages/oauth2/test/unit/domains/token/create.spec.ts
@@ -18,6 +18,7 @@ const tokenGrantResponse : TokenGrantResponse = {
     mac_algorithm: 'mac_algorithm',
     token_type: 'Bearer',
     expires_in: 3600,
+    refresh_token_expires_in: 7200,
     access_token: 'access_token',
     refresh_token: 'refresh_token',
     id_token: 'id_token',


### PR DESCRIPTION
## Description

`TokenAPI.create()` normalizes the token endpoint response into a fixed `TokenGrantResponse` shape and only copies a known set of fields (`access_token`, `expires_in`, `token_type`, `refresh_token`, `id_token`, `mac_key`, `mac_algorithm`). A `refresh_token_expires_in` value returned by the authorization server was silently discarded — so consumers (e.g. a client wanting to schedule re-login before the refresh token itself expires) never received it.

## Changes

- Add `refresh_token_expires_in?: number` to `TokenGrantResponse`.
- Copy the field in `TokenAPI.create()` when present, alongside the other optional fields.
- Extend the `create.spec.ts` fixture with `refresh_token_expires_in` for regression coverage (every `create*` test asserts the full response via `toEqual`).

## Verification

- `npm run build --workspace=packages/oauth2`
- `npm run test --workspace=packages/oauth2` — 23 tests passed
- ESLint clean on the changed files

Closes #1022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for refresh token expiration information in OAuth2 token responses, enabling applications to determine when refresh tokens expire.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->